### PR TITLE
Fix php8 compatibility with call_user_func_array

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.3.0",
+		"php": "^5.3 || ^7.0 || ^8.0",
 		"ext-pcntl": "*",
 		"colinmollenhour/credis": "~1.2",
 		"psr/log": "1.0.0"

--- a/lib/Resque/Event.php
+++ b/lib/Resque/Event.php
@@ -34,7 +34,7 @@ class Resque_Event
 			if (!is_callable($callback)) {
 				continue;
 			}
-			call_user_func_array($callback, $data);
+			call_user_func_array($callback, array_values($data));
 		}
 		
 		return true;


### PR DESCRIPTION
Since php8.0 call_user_func_array will use array keys as parameter names ( named argument)
A few events are triggered with arguments with keys, causing errors