### PR TITLE
correctly crash worker on Redis Exception

### DIFF
--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -280,6 +280,28 @@ class Resque_Redis
 		}
 	}
 
+    /**
+     * @param string $key
+     * @return false|string|null
+     */
+    public function lpop($key)
+    {
+        return $this->driver->lPop(self::$defaultNamespace . $key);
+    }
+
+    /**
+     * @param string[] $keys
+     * @param int $timeout
+     * @return array|null
+     */
+    public function blpop(array $keys, $timeout)
+    {
+        foreach ($keys as $i => $key) {
+            $keys[$i] = self::$defaultNamespace . $key;
+        }
+        return $this->driver->blPop($keys, $timeout);
+    }
+
 	public static function getPrefix()
 	{
 	    return self::$defaultNamespace;


### PR DESCRIPTION
Extracted the specific `pop` calls from generic __call with catchAll so it correctly crashes.
__call: https://github.com/ScientaNL/php-resque/blob/master/lib/Resque/Redis.php#L215-L233