### PR TITLE
Catch Redis connection errors in lpop/blpop

### DIFF
--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -286,7 +286,12 @@ class Resque_Redis
      */
     public function lpop($key)
     {
-        return $this->driver->lPop(self::$defaultNamespace . $key);
+        try {
+            return $this->driver->lPop(self::$defaultNamespace . $key);
+        } catch (CredisException | RedisClusterException | RedisException $e) {
+            $this->logger->error($this->formatErrorAsString($e));
+            return false;
+        }
     }
 
     /**
@@ -299,7 +304,12 @@ class Resque_Redis
         foreach ($keys as $i => $key) {
             $keys[$i] = self::$defaultNamespace . $key;
         }
-        return $this->driver->blPop($keys, $timeout);
+        try {
+            return $this->driver->blPop($keys, $timeout);
+        } catch (CredisException | RedisClusterException | RedisException $e) {
+            $this->logger->error($this->formatErrorAsString($e));
+            return null;
+        }
     }
 
 	public static function getPrefix()


### PR DESCRIPTION
The lpop() and blpop() dequeue methods called the Credis/phpredis driver directly, bypassing the CredisException|RedisException catch that __call() already applies to every other command. A transient connection failure (e.g. a Valkey/ElastiCache failover) raised an uncaught exception out of the worker's dequeue loop, killing the worker process.

Wrap both methods in the same catch __call() uses and return the empty-result sentinel (false for lpop, null for blpop). Resque::pop() and Resque::blpop() already treat that as an empty queue, so the worker sleeps and retries on the next loop iteration and recovers once the connection is restored.